### PR TITLE
Added the appElevation to the other breakpoints

### DIFF
--- a/lib/templates/layout/scaffold.dart
+++ b/lib/templates/layout/scaffold.dart
@@ -113,6 +113,7 @@ class ResponsiveScaffold extends StatelessWidget {
                     ),
                   ),
             appBar: AppBar(
+              elevation: appBarElevation,
               automaticallyImplyLeading: false,
               title: title,
               leading: _MenuButton(iconData: menuIcon),
@@ -174,6 +175,7 @@ class ResponsiveScaffold extends StatelessWidget {
                   ),
                 ),
           appBar: AppBar(
+            elevation: appBarElevation,
             automaticallyImplyLeading: false,
             leading: _MenuButton(iconData: menuIcon),
             title: title,


### PR DESCRIPTION
In #8 the `appElevation` field was added to the `ResponsiveScaffold`, but it was only added to the desktop breakpoint. This mistake happened because of ignorance in regard to the  layout of the `ResponsiveScaffold` widget.

This was spotted when the app was tested on mobile and the lack of elevation compliance was clearly visible: 
<a href="https://imgbb.com/"><img src="https://i.ibb.co/f9p7QGg/Screenshot-2020-02-07-at-20-49-16.png" alt="Screenshot-2020-02-07-at-20-49-16" border="0"></a>

This is a mistake with the commit that introduced the feature: [59fe621](https://github.com/fluttercommunity/responsive_scaffold/commit/59fe621e7acfc053258512e6c7e2b74cf0e0282b)